### PR TITLE
Add link to blogpost about building a slack clone

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ Tailwind CSS is a utility-first CSS framework for rapidly building custom user i
 - [Plugin Examples (Official)](https://github.com/tailwindcss/plugin-examples)
 - [Rebuilding Twitter with Tailwind CSS](https://www.youtube.com/watch?v=Pg_5Ni1_bg4) - [CodePen](https://codepen.io/drehimself/full/vpeVMx)
 - [Rebuilding YouTube with Tailwind CSS + plugins](https://www.youtube.com/watch?v=qxQKnqmNKv0)
+- [Building a Slack clone using Laravel, Tailwind CSS and Vue.js](https://blog.pusher.com/slack-clone-laravel-tailwindcss-vuejs/)
 - [Add Your Item](https://github.com/merchedhq/awesome-tailwindcss/pulls)
 
 


### PR DESCRIPTION
The blogpost doesn't cover _how_ I built the homepage clone, though. Does it still fit? The demo uses it though, and the code is posted in the [TailwindComponents page](https://tailwindcomponents.com/component/slackish-homepage)