### PR TITLE
Add AstroDeck and Brook 2 templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@
 - 📁 [Astro Template Cactus](https://github.com/chrismwilliams/astro-theme-cactus) - Tailwind CSS Astro starter template.
 - 📁 [Astro Template Ovidius](https://github.com/JustGoodUI/ovidius-astro-theme) - Tailwind CSS & Astro blog template.
 - 📁 [Astro Template Dante](https://github.com/JustGoodUI/dante-astro-theme) - Tailwind CSS & Astro blog/portfolio template.
+- 📁 [AstroDeck](https://github.com/holger1411/astrodeck) - Production-ready Astro 6 starter with Tailwind CSS 4, shadcn/ui, dark mode and AI agent support.
+- 📁 [Brook 2](https://github.com/holger1411/astro-brook) - Minimalist Astro 6 blog template built with Tailwind CSS 4, content collections and dark mode.
 
 ## Plugins
 


### PR DESCRIPTION
| Name | Link |
| ---- | ---- |
| AstroDeck | https://github.com/holger1411/astrodeck |
| Brook 2 | https://github.com/holger1411/astro-brook |

Adds two free, open-source Astro 6 + Tailwind CSS 4 templates to the "UI libraries, components & templates" section:

- **AstroDeck** — Production-ready starter with shadcn/ui, dark mode, 11 page templates and AI agent support (AGENTS.md). Demo: https://www.astrodeck.dev/
- - **Brook 2** — Minimalist blog template with content collections, MDX and dark mode. Demo: https://brook2-astro-blog.vercel.app/
Both are MIT-licensed and part of the [TemplateDeck](https://templatedeck.com) collection.

---

- [x] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/CONTRIBUTING.md)
- [ ] - [x] My item is in the right category
- [ ] - [x] My item is logically grouped below similar items
- [ ] - [x] My item's name and description respects the conventions of the list
- [ ] - [x] My item is awesome, and I really mean it
- [ ] - [x] My item is in line with the [Tailwind brand usage guidelines](https://tailwindcss.com/brand#usage)