### PR TITLE
add(tools): Deslint — design-system + a11y linter for Tailwind CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 - 🌐 [Gimli Tailwind](https://chromewebstore.google.com/detail/gimli-tailwind/fojckembkmaoehhmkiomebhkcengcljl) - Smart tools for Tailwind CSS as a browser extension.
 - 🌐 [CSS Variables Editor](https://www.cssvariables.com) - AI-powered Chrome extension for managing colors in daisyUI and shadcn/ui.
 - 🌐 [DivMagic](https://divmagic.com) - Copy any web element and style as Tailwind CSS component.
+- 🅰 [Deslint](https://github.com/jaydrao215/deslint) - Enforces design-system discipline in Tailwind CSS by flagging arbitrary colors, spacing, typography, and z-index values across React, Vue, Svelte, Angular, and plain HTML — with auto-fix and a WCAG 2.2 accessibility rule set.
 
 ## UI libraries, components & templates
 


### PR DESCRIPTION
Adds [Deslint](https://github.com/jaydrao215/deslint), a Tailwind-aware ESLint plugin that enforces design-system discipline on Tailwind CSS class usage and catches WCAG accessibility failures in AI-generated frontend code.

**What it catches in Tailwind class usage:**
- `no-arbitrary-colors` — `bg-[#FF0000]` → token (auto-fix)
- `no-arbitrary-spacing` — `p-[13px]` → scale (auto-fix)
- `no-arbitrary-typography` — arbitrary `text-[Npx]`, `leading-[N]`, `tracking-[N]` → scale (auto-fix)
- `no-arbitrary-zindex` — `z-[999]` → token (auto-fix)
- `no-magic-numbers-layout` — arbitrary grid/flex values (auto-fix)
- `consistent-component-spacing` / `consistent-border-radius` — drift across components
- `responsive-required` — fixed-width containers without responsive breakpoints
- `dark-mode-coverage` — elements missing `dark:` variants

**Plus 8 WCAG 2.2 / 2.1 AA accessibility rules** — 13 Success Criteria covered.

- Supports Tailwind CSS v3 and v4 (including `@theme` CSS parsing).
- Framework-agnostic: React, Vue, Svelte, Angular, plain HTML.
- 1,145 tests; 0 false positives across 4,061 files in 7 real projects.
- ESLint v10+ flat config only.
- npm: https://www.npmjs.com/package/@deslint/eslint-plugin
- License: MIT

Checklist:
- [x] Entry uses "Tailwind CSS" (not "Tailwind" or "TailwindCSS")
- [x] Description starts with a verb ("Enforces")
- [x] Description is capitalized and ends with a period
- [x] Added to bottom of the 🅰 emoji group in Tools
- [x] Conventional-commits PR title