### PR TITLE
add(templates): Next.js landing template

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@
 - 📁 [Astro Template Cactus](https://github.com/chrismwilliams/astro-theme-cactus) - Tailwind CSS Astro starter template.
 - 📁 [Astro Template Ovidius](https://github.com/JustGoodUI/ovidius-astro-theme) - Tailwind CSS & Astro blog template.
 - 📁 [Astro Template Dante](https://github.com/JustGoodUI/dante-astro-theme) - Tailwind CSS & Astro blog/portfolio template.
+- 📁 [Next.js Landing Template](https://github.com/R3D-SH3LL/nextjs-landing-template) - Next.js landing page starter built with Tailwind CSS.
 
 ## Plugins
 


### PR DESCRIPTION
Adding a Next.js landing page starter template to the templates section.

- 📁 [Next.js Landing Template](https://github.com/R3D-SH3LL/nextjs-landing-template) - Next.js landing page starter built with Tailwind CSS.

**Stack:** Next.js 16, TypeScript, Tailwind CSS 4, shadcn/ui
**Demo:** https://nextjs-landing-template-q5xncavhi-nexus-monitor.vercel.app
**License:** MIT