### PR TITLE
add(ui-libraries): StyleSeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 - 🧩 [8bitcn UI](https://8bitcn.com) - Re-usable retro components built using Shadcn UI and Tailwind CSS.
 - 🧩 [Xtend UI](https://github.com/xtendui/xtendui) - Tailwind CSS components with advanced interactions and animations.
 - 🧩 [Tremor](https://tremor.so) - React library to build charts and dashboards with Tailwind CSS.
+- 🧩 [StyleSeed](https://github.com/bitjaru/styleseed) - Design engine with 48 shadcn-style React components, 69 design rules, and swappable brand skins (Toss, Stripe, Linear, Vercel, Notion) built on Tailwind CSS v4 and Radix UI.
 - 📚 [Daisy UI](https://github.com/saadeghi/daisyui) - UI Components for Tailwind CSS.
 - 📚 [Flowbite](https://flowbite.com/docs/getting-started/introduction/) - Component library built with Tailwind CSS.
 - 📚 [STDF](https://stdf.design) - Mobile web component library based on Svelte and Tailwind CSS.


### PR DESCRIPTION
Adding **StyleSeed** to the UI libraries, components & templates section under the 🧩 (copy-pastable components) group.

**Link:** https://github.com/bitjaru/styleseed

StyleSeed is an open-source design engine built on Tailwind CSS v4 and Radix UI. It provides 48 shadcn-style React components, 69 documented design rules, and swappable brand skins (Toss, Stripe, Linear, Vercel, Notion). MIT licensed.

### Checklist
- [x] Description starts with a capital letter and ends with a period
- [x] Does not start with "A", "An", or "The"
- [x] Uses the exact phrase "Tailwind CSS"
- [x] Placed in the correct emoji group (🧩 copy-pastable components)
- [x] Appended to the bottom of the 🧩 group
- [x] Single resource per PR