### PR TITLE
add(tool): add Base-2 Rounding to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 - 🎨🌍🔧 [Tints](https://www.tints.dev/) - Color palette generator and API for Tailwind CSS.
 - 🎨🌍🔧 [Fullwind CSS](https://fullwindcss.com/) - Extend Tailwind CSS color palettes with additional shades.
 - 🎨🌍🔧 [Inclusive colors](https://www.inclusivecolors.com/) - Create fine-tuned WCAG accessible Tailwind CSS color palettes.
+- 🌍🔧 [Base-2 Rounding](https://objectivelyround.dev) - Spacing and sizing value picker for Tailwind CSS v4's bracketless arbitrary values.
 - 🔼🌍 [Prefixer](https://github.vue.tailwind-prefix.cbass.dev) - Tailwind classes' prefixer tool.
 - 🔼 [RustyWind](https://github.com/avencera/rustywind) - CLI tool for sorting Tailwind CSS classes.
 - 🔼 [Tailwind to Inline styles converter](https://github.com/vardan-arm/tailwind-to-inline) - Converts Tailwind CSS classes to inline styles in email templates.
@@ -77,7 +78,6 @@
 - 🌐 [Gimli Tailwind](https://chromewebstore.google.com/detail/gimli-tailwind/fojckembkmaoehhmkiomebhkcengcljl) - Smart tools for Tailwind CSS as a browser extension.
 - 🌐 [CSS Variables Editor](https://www.cssvariables.com) - AI-powered Chrome extension for managing colors in daisyUI and shadcn/ui.
 - 🌐 [DivMagic](https://divmagic.com) - Copy any web element and style as Tailwind CSS component.
-- 🌍 [Base-2 Rounding](https://objectivelyround.dev) - Spacing and sizing value picker for Tailwind CSS v4’s bracketless arbitrary values.
 
 ## UI libraries, components & templates
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 - 🌐 [Gimli Tailwind](https://chromewebstore.google.com/detail/gimli-tailwind/fojckembkmaoehhmkiomebhkcengcljl) - Smart tools for Tailwind CSS as a browser extension.
 - 🌐 [CSS Variables Editor](https://www.cssvariables.com) - AI-powered Chrome extension for managing colors in daisyUI and shadcn/ui.
 - 🌐 [DivMagic](https://divmagic.com) - Copy any web element and style as Tailwind CSS component.
+- 🌍 [Base-2 Rounding](https://objectivelyround.dev) - Spacing and sizing value picker for Tailwind CSS v4’s bracketless arbitrary values.
 
 ## UI libraries, components & templates
 


### PR DESCRIPTION
<!-- Please fill the table and check the cases below. If this template is not filled properly, your pull request might be rejected. -->

| Name                 | Link                 |
| -------------------- | -------------------- |
| _Base-2 Rounding_ | _https://objectivelyround.dev_ |

_An online tool to help Tailwind CSS v4 users choose sensible spacing and sizing values, in line with the previous spacing scale, now that brackets are no longer required for arbitrary values. The site includes an explanation and example output._

---

- [x] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/CONTRIBUTING.md)
- [x] My item is in the right category
- [x] My item is logically grouped below similar items
- [x] My item's name and description respects the conventions of the list
- [x] My item is awesome, and I really mean it
- [x] My item is in line with the [Tailwind brand usage guidelines](https://tailwindcss.com/brand#usage)

~There weren't other tools with just 🌍, so I added it at the end of the list. Happy to move it if you'd prefer it somewhere else.~