### PR TITLE
Add shieldcn

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - 🌐 [Gimli Tailwind](https://chromewebstore.google.com/detail/gimli-tailwind/fojckembkmaoehhmkiomebhkcengcljl) - Smart tools for Tailwind CSS as a browser extension.
 - 🌐 [CSS Variables Editor](https://www.cssvariables.com) - AI-powered Chrome extension for managing colors in daisyUI and shadcn/ui.
 - 🌐 [DivMagic](https://divmagic.com) - Copy any web element and style as Tailwind CSS component.
+- 🌍🔧 [shieldcn](https://shieldcn.dev) - Shields.io alternative rendering badges as shadcn/ui components styled with Tailwind CSS.
 
 ## UI libraries, components & templates
 


### PR DESCRIPTION
[shieldcn](https://shieldcn.dev) is a shields.io alternative that renders GitHub README badges as shadcn/ui Button components using Satori and Tailwind CSS. It uses Tailwind CSS v4 for its design system and resolves shadcn Button design tokens (bg, fg, border per variant) to hex values for SVG rendering.

Supports npm, GitHub, Discord, Reddit, and static badges with dark/light mode, 6 variants, and 40,000+ icons.

**Added to**: Tools section as 🌍🔧 (accessible online, generator)

- [x] Follows the format: `[Item name](link) - Description.`
- [x] Description starts with uppercase, ends with period
- [x] Description is short and explicit
- [x] Every mention uses the exact name `Tailwind CSS`