### PR TITLE
add(ui-libraries): User Tour Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@
 - 📚 [STDF](https://stdf.design) - Mobile web component library based on Svelte and Tailwind CSS.
 - 📚 [Preline UI](https://preline.co) - Open-source Tailwind CSS components library for any needs.
 - 📚 [Date picker](https://github.com/themesberg/tailwind-datepicker) - Adds a datepicker component built with Tailwind CSS and vanilla JavaScript.
+- 📚 [User Tour Kit](https://github.com/domidex01/tour-kit) - Headless onboarding components — product tours, hints, checklists, and surveys with Tailwind CSS-friendly defaults.
 - 📁 [Built at lightspeed](https://www.builtatlightspeed.com/) - Massive directory of 500+ Tailwind templates, starters and UI kits.
 - 📁 [Admin One Vue 3](https://github.com/justboil/admin-one-vue-tailwind) - Free Vue.js 3 Tailwind CSS admin template with Vite & Vue CLI support.
 - 📁 [Admin One React](https://github.com/justboil/admin-one-react-tailwind) - Free React.js Tailwind CSS admin template with Next.js & TypeScript.


### PR DESCRIPTION
Adding [User Tour Kit](https://github.com) — a headless React onboarding library that pairs naturally with Tailwind CSS.

User Tour Kit ships zero styles by default. Every component accepts `className` and the render-prop API lets you fully control markup. Tailwind CSS users typically style tours, hints, and checklists in 10–20 lines of utility classes. Defaults match shadcn/ui design tokens for instant integration.

Per CONTRIBUTING.md:
- Format: `[Item name](link) - Description.` ✓
- Description doesn't start with "The"/"A" ✓
- "Tailwind CSS" used in full where applicable ✓
- Added to bottom of 📚 UI library emoji group ✓

Docs: https://
