### PR TITLE
Add TinyTools — Tailwind color palette generator with WCAG built in

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 - 🎨🌍🔧 [Tints](https://www.tints.dev/) - Color palette generator and API for Tailwind CSS.
 - 🎨🌍🔧 [Fullwind CSS](https://fullwindcss.com/) - Extend Tailwind CSS color palettes with additional shades.
 - 🎨🌍🔧 [Inclusive colors](https://www.inclusivecolors.com/) - Create fine-tuned WCAG accessible Tailwind CSS color palettes.
+- 🎨🌍🔧 [TinyTools](https://tinytools-smoky.vercel.app/color-palette/for-tailwind-users/) - Generate a complete Tailwind 50–950 color scale (v3 + v4 `@theme`) with WCAG contrast scoring built in. No signup.
 - 🌍🔧 [Base-2 Rounding](https://objectivelyround.dev) - Spacing and sizing value picker for Tailwind CSS v4's bracketless arbitrary values.
 - 🔼🌍 [Prefixer](https://github.vue.tailwind-prefix.cbass.dev) - Tailwind classes' prefixer tool.
 - 🔼 [RustyWind](https://github.com/avencera/rustywind) - CLI tool for sorting Tailwind CSS classes.


### PR DESCRIPTION
Hi! Submitting a free, no-signup Tailwind-specific color palette generator that complements the existing color tools in the list.

**TinyTools — Color Palette for Tailwind CSS**
https://tinytools-smoky.vercel.app/color-palette/for-tailwind-users/

**What it does (different from existing entries):**
- Generates a complete 50→950 color scale from any base accent
- Outputs both Tailwind v3 (`tailwind.config.js`) and v4 (`@theme` directive) formats
- WCAG 4.5:1 (AA) and 7:1 (AAA) contrast scoring on every shade pair, inline
- 100% free, no signup, no ads, no tracking
- Pure browser tool — palette never leaves your device
- Open source: https://github.com/alfredoautomatizaloconia-cloud/tinytools

Placed alphabetically among the 🎨🌍🔧 color tools after 'Inclusive colors'. Uses the existing legend icons (🎨 color · 🌍 online · 🔧 generator).

Happy to revise the description or placement if you'd prefer different wording.