### PR TITLE
add(library): Billing SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 - 🧩 [8bitcn UI](https://8bitcn.com) - Re-usable retro components built using Shadcn UI and Tailwind CSS.
 - 🧩 [Xtend UI](https://github.com/xtendui/xtendui) - Tailwind CSS components with advanced interactions and animations.
 - 🧩 [Tremor](https://tremor.so) - React library to build charts and dashboards with Tailwind CSS.
+- 🧩 [Billing SDK](https://billingsdk.com) - React billing and subscription components (pricing tables, usage meters, plan upgrade flows) built with Tailwind CSS and shadcn/ui.
 - 📚 [Daisy UI](https://github.com/saadeghi/daisyui) - UI Components for Tailwind CSS.
 - 📚 [Flowbite](https://flowbite.com/docs/getting-started/introduction/) - Component library built with Tailwind CSS.
 - 📚 [STDF](https://stdf.design) - Mobile web component library based on Svelte and Tailwind CSS.


### PR DESCRIPTION
Adds [Billing SDK](https://billingsdk.com) to the `UI libraries, components & templates` section under the `🧩` (Copy-pastable components) group, at the bottom per CONTRIBUTING guidelines.

Billing SDK is an open-source collection of React billing and subscription components (pricing tables, usage meters, plan upgrade flows, cancellation flows) built with Tailwind CSS and shadcn/ui. Part of the [Vercel OSS Program](https://vercel.com/oss).

- Repo: https://github.com/dodopayments/billingsdk
- Docs: https://billingsdk.com/docs
- License: GPL