### PR TITLE
add(tools): Linkshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 - 💼 [Config viewer](https://github.com/rogden/tailwind-config-viewer) - Local UI tool for visualizing your Tailwind CSS configuration file.
 - 💼 [Raycast extension](https://www.raycast.com/vimtor/tailwindcss) - Search classes, documentation and colors in Raycast Launcher.
 - 💼 [NativeWind](https://www.nativewind.dev) - Uses Tailwind CSS as scripting language to create a universal style system for React Native.
+- 💼 [Linkshot](https://uselinkshot.com) - Open Graph image API with Tailwind CSS injection and a `linkshot:` modifier for capture-only styles.
 - 🌐 [Gimli Tailwind](https://chromewebstore.google.com/detail/gimli-tailwind/fojckembkmaoehhmkiomebhkcengcljl) - Smart tools for Tailwind CSS as a browser extension.
 - 🌐 [CSS Variables Editor](https://www.cssvariables.com) - AI-powered Chrome extension for managing colors in daisyUI and shadcn/ui.
 - 🌐 [DivMagic](https://divmagic.com) - Copy any web element and style as Tailwind CSS component.


### PR DESCRIPTION
Adds Linkshot to the Tools section under the 💼 emoji group.

Linkshot is a hosted Open Graph image API that injects Tailwind CSS into live page screenshots at capture time. It introduces a custom `linkshot:` modifier (e.g. `<nav class="linkshot:hidden">`) that activates only during screenshot capture — letting you hide navbars, cookie banners, or chat widgets in OG images without affecting the live page.

- Website: https://.com
- Docs: https://.com/docs

Format follows CONTRIBUTING.md:

- Item placed at the bottom of its emoji group (💼)
- Uses exact name `Tailwind CSS`
- Description is short, explicit, ends with a period
- Does not start with "A" or "The"
- Does not violate Tailwind brand usage guidelines

`awesome-lint` and `case-police` both pass locally.