### PR TITLE
Add OTF UI to UI libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@
 - 🧩 [8bitcn UI](https://8bitcn.com) - Re-usable retro components built using Shadcn UI and Tailwind CSS.
 - 🧩 [Xtend UI](https://github.com/xtendui/xtendui) - Tailwind CSS components with advanced interactions and animations.
 - 🧩 [Tremor](https://tremor.so) - React library to build charts and dashboards with Tailwind CSS.
-- 🧩 [OTF UI](https://otf-kit.dev/components) - Cross-platform shadcn-CLI-compatible components for Next.js (Tailwind CSS v4 + Radix) and Expo (Tamagui) from one parity API.
+- 📚 [OTF UI](https://otf-kit.dev/components) - Cross-platform component library for Next.js (Tailwind CSS v4 + Radix) and Expo (Tamagui) from one parity API.
 - 📚 [Daisy UI](https://github.com/saadeghi/daisyui) - UI Components for Tailwind CSS.
 - 📚 [Flowbite](https://flowbite.com/docs/getting-started/introduction/) - Component library built with Tailwind CSS.
 - 📚 [STDF](https://stdf.design) - Mobile web component library based on Svelte and Tailwind CSS.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 - 🧩 [8bitcn UI](https://8bitcn.com) - Re-usable retro components built using Shadcn UI and Tailwind CSS.
 - 🧩 [Xtend UI](https://github.com/xtendui/xtendui) - Tailwind CSS components with advanced interactions and animations.
 - 🧩 [Tremor](https://tremor.so) - React library to build charts and dashboards with Tailwind CSS.
+- 🧩 [OTF UI](https://otf-kit.dev/components) - Cross-platform shadcn-CLI-compatible components for Next.js (Tailwind CSS v4 + Radix) and Expo (Tamagui) from one parity API.
 - 📚 [Daisy UI](https://github.com/saadeghi/daisyui) - UI Components for Tailwind CSS.
 - 📚 [Flowbite](https://flowbite.com/docs/getting-started/introduction/) - Component library built with Tailwind CSS.
 - 📚 [STDF](https://stdf.design) - Mobile web component library based on Svelte and Tailwind CSS.


### PR DESCRIPTION
OTF UI is a shadcn-CLI-compatible component library built on Tailwind CSS v4 + Radix for web, with a mobile parity counterpart on Tamagui exposing the same API.

Live demos: https://otf-kit.dev/components · npm: `@otfdashkit/ui` · Install: `npx shadcn@latest add https://otf-kit.dev/r/<name>.json`

Tagged 🧩 (copy-pastable) to match shadcn UI, Tremor, and the other shadcn-distributed entries in the section.