### PR TITLE
Add srb/ui to UI libraries, components and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 - 🧩 [8bitcn UI](https://8bitcn.com) - Re-usable retro components built using Shadcn UI and Tailwind CSS.
 - 🧩 [Xtend UI](https://github.com/xtendui/xtendui) - Tailwind CSS components with advanced interactions and animations.
 - 🧩 [Tremor](https://tremor.so) - React library to build charts and dashboards with Tailwind CSS.
+- 🧩 [srb/ui](https://ui.srb.codes) - Production-ready UI blocks and components built with Tailwind CSS, shadcn/ui and Framer Motion.
 - 📚 [Daisy UI](https://github.com/saadeghi/daisyui) - UI Components for Tailwind CSS.
 - 📚 [Flowbite](https://flowbite.com/docs/getting-started/introduction/) - Component library built with Tailwind CSS.
 - 📚 [STDF](https://stdf.design) - Mobile web component library based on Svelte and Tailwind CSS.


### PR DESCRIPTION
## srb/ui

Adding **srb/ui** to the "UI libraries, components & templates" section.

- URL: https://ui.srb.codes
- Stack: Tailwind CSS v4, shadcn/ui, Radix UI, Framer Motion
- Copy-paste components: hero sections, CTAs, feature blocks, testimonials
- Distributed via shadcn CLI registry pattern
- Actively maintained with new components added regularly