### PR TITLE
Add OTF UI to UI libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@
 - 📚 [Flowbite](https://flowbite.com/docs/getting-started/introduction/) - Component library built with Tailwind CSS.
 - 📚 [STDF](https://stdf.design) - Mobile web component library based on Svelte and Tailwind CSS.
 - 📚 [Preline UI](https://preline.co) - Open-source Tailwind CSS components library for any needs.
+- 📚 [OTF UI](https://otf-kit.dev/components) - Cross-platform component library built on Tailwind CSS v4 and Radix, with mobile parity via Tamagui. MIT.
 - 📚 [Date picker](https://github.com/themesberg/tailwind-datepicker) - Adds a datepicker component built with Tailwind CSS and vanilla JavaScript.
 - 📁 [Built at lightspeed](https://www.builtatlightspeed.com/) - Massive directory of 500+ Tailwind templates, starters and UI kits.
 - 📁 [Admin One Vue 3](https://github.com/justboil/admin-one-vue-tailwind) - Free Vue.js 3 Tailwind CSS admin template with Vite & Vue CLI support.


### PR DESCRIPTION
Adds OTF UI (https://) — a free MIT cross-platform component library built on Tailwind CSS v4 and Radix on the web, with mobile parity via Tamagui (NativeWind-compatible). 215+ components, dark-mode-native, accessible.

Why it fits this list: most entries in the UI libraries section are web-only. OTF UI is one of the few that uses Tailwind CSS as its web foundation but extends the same component API to Expo / React Native, so a Tailwind dev can share components across both platforms.

Live demo: https://
Storybook: https://
Docs: https://

Happy to adjust phrasing or position — let me know.

— Dave