### PR TITLE
Add otf-ui to UI libraries, components & templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 - 💙📚 [Headless UI](https://headlessui.com/) - Completely unstyled, fully accessible UI components.
 - 💙📁 [Catalyst](https://tailwindcss.com/plus/ui-kit) - Beautiful, accessible application UI kit for React.
 - 🧩 [shadcn UI](https://ui.shadcn.com) - Re-usable components built using Radix UI and Tailwind CSS.
+- 📚🧩 [otf-ui](https://otf-kit.dev/components) - Cross-platform components for React (Radix + Tailwind v4) and React Native (Tamagui) with one shared API.
 - 🧩 [Layouts for Tailwind](https://layoutsfortailwind.lalokalabs.dev) - Layouts and UI patterns for Tailwind CSS.
 - 🧩 [Meraki UI Components](https://merakiui.com) - Beautiful Tailwind CSS components that support RTL languages.
 - 🧩 [Kometa UI Kit](https://kitwind.io/products/kometa/components) - Free multi-purpose UI kit, built with Tailwind CSS.


### PR DESCRIPTION
Adds **otf-ui** to *UI libraries, components & templates*.

- **Link:** https://otf-kit.dev/components
- Free & open-source (MIT). Built on **Radix + Tailwind CSS v4** for web, with the same component API on React Native (Tamagui) — write once, ship to web + mobile.
- npm install **or** copy-paste (shadcn-style CLI). 215+ components, Storybook for every variant.

Placed next to the shadcn UI entry as the cross-platform option for the same audience. Thanks for maintaining the list!